### PR TITLE
#3 Remove settings from Conan recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,6 @@ class SequencesConan(ConanFile):
     url = homepage
     license = "MIT"
     author = "taocpp@icemx.net"
-    settings = "compiler", "arch"
     exports = "LICENSE"
     exports_sources = "include/*", "CMakeLists.txt"
     no_copy_source = True


### PR DESCRIPTION
Hi!

@d-frey I don't have permission to push on this project, so I forked it ;)

AS I commented before, Conan 1.5.0 relaxed rules to create header-only package, using CMake on Windows. So we are able to remove settings now.

close #3 